### PR TITLE
Possibility to open links from history (via double click)

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -499,8 +499,9 @@ function loadIntoWindow(window) {
 					let t = $(addon.tag+'-listbox'), d = getSkipDomA(), cc = 0;
 					for(let l in cltrack) {
 						try {
-							let u1 = Services.io.newURI(l,null,null), c1, c2,
-								u2 = Services.io.newURI(cltrack[l],null,null);
+							let u1 = Services.io.newURI(l,null,null),
+								u2 = Services.io.newURI(cltrack[l],null,null),
+								c1, c2, item;
 							if(~d.indexOf(u1.asciiHost)) continue;
 							c1 = e('listcell',{
 								label:l,style:'max-width:310px',
@@ -508,7 +509,10 @@ function loadIntoWindow(window) {
 							c2 = e('listcell',{
 								label:u2.spec,style:'max-width:270px',
 								'class':'listcell-iconic', crop:'right'})
-							e('listitem',{allowevents:!0,maxheight:18},[c1,c2],t);
+							item = e('listitem',{allowevents:!0,maxheight:18},[c1,c2],t);
+							item.addEventListener("dblclick", function(event) {
+								window.gBrowser.selectedTab = window.gBrowser.addTab(event.target.value);
+							});
 							setFavicon(u1,c1);
 							setFavicon(u2,c2);
 							++cc;

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -74,9 +74,13 @@ let i$ = {
 		if(!win.diegocr)
 			return null;
 
-		let bro = win.diegocr[addon.tag],
-			clt = bro.cl(link,base);
+		let bro = win.diegocr[addon.tag];
+		if(bro.skip) {
+			bro.skip = false;
+			return null;
+		}
 
+		let clt = bro.cl(link,base);
 		LOG([link,clt]);
 		return (clt != link) ? (bro.blink(win), clt) : null;
 	},
@@ -511,6 +515,7 @@ function loadIntoWindow(window) {
 								'class':'listcell-iconic', crop:'right'})
 							item = e('listitem',{allowevents:!0,maxheight:18},[c1,c2],t);
 							item.addEventListener("dblclick", function(event) {
+								window.diegocr[addon.tag].skip = true;
 								window.gBrowser.selectedTab = window.gBrowser.addTab(event.target.value);
 							});
 							setFavicon(u1,c1);


### PR DESCRIPTION
This is particularly useful if a link was cleaned in error and one quickly wants to open the uncleaned link.

There is one difficulty:
By default the "http-on-modify-request" observer cleans all opened links, there's no possibility to prevent this (basically that's exactly what we want but obviously it's problematic if we want to open uncleaned links).
I addressed this in commit b37666a (which allows links to be skipped from cleaning). I'm not sure if it's the best solution, so if there were better alternatives I'd be open to change the approach.