### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-##CleanLinks Mozilla Firefox Extension [![Stories in Ready](https://badge.waffle.io/diegocr/cleanlinks.png?label=ready)](https://waffle.io/diegocr/cleanlinks)  
+## CleanLinks Mozilla Firefox Extension [![Stories in Ready](https://badge.waffle.io/diegocr/cleanlinks.png?label=ready)](https://waffle.io/diegocr/cleanlinks)  
 
 This Extension is designed to convert obfuscated/nested links to genuine/normal plain clean links.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
